### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @charmed-hpc/python-reviewers


### PR DESCRIPTION
Automatically tag `python-reviewers` when a new PR is opened against this repository.