### PR TITLE
ci: fix build to run on non-destructive mode

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,6 +26,8 @@ parts:
       - astral-uv
     charm-requirements: ["requirements.txt"]
     override-build: |
+      # hack to get around a weird incompatibility between destructive and non-destructive mode
+      cp $CRAFT_PROJECT_DIR/charmcraft.yaml $CRAFT_PART_BUILD/charmcraft.yaml
       just requirements
       charmcraft fetch-libs
       craftctl default


### PR DESCRIPTION
Just a hack to get around a weird incompatibility between non-destructive and destructive builds.